### PR TITLE
#11 Added modifier that updates the foreground color to green

### DIFF
--- a/IceCreamFlavors/DetailView/DetailRatingsView.swift
+++ b/IceCreamFlavors/DetailView/DetailRatingsView.swift
@@ -18,7 +18,7 @@ struct DetailRatingsView: View {
         HStack {
             ForEach(rating, id:\.self){item in
                 Image(systemName: item)
-                    //.foregroundColor(.green)
+                    .foregroundColor(.green)
             }
         }
     }


### PR DESCRIPTION
Closes #11 

## What It Does

This PR adds a modifier that updates the foreground color to green.

## How To Test

- Launch the app
- Select an Ice Cream Flavor to view its details
- Verify that the rating color is green

## Screenshots

<img src="https://user-images.githubusercontent.com/16762986/93834001-63c63380-fc48-11ea-9ed8-27989402d979.png" width=300 />


