### PR TITLE
#8 Adds shadow modifier to 'DetailImageView'

### DIFF
--- a/IceCreamFlavors/DetailView/DetailImageView.swift
+++ b/IceCreamFlavors/DetailView/DetailImageView.swift
@@ -14,7 +14,7 @@ struct DetailImageView: View {
         Image("\(flavorItem.id)_Flavor")
         .resizable()
         .scaledToFit()
-        //.shadow(color: .black, radius:10, x:5, y:5)
+        .shadow(color: .black, radius:15, x:5, y:5)
     }
 }
 


### PR DESCRIPTION
Closes #8 

## What it does

This pull request updates the modifier of the `DetailImageView`. It adds a shadow to the image.

## How to test

- Launch the app
- Tap on any ice cream
- Check the main ice cream image with the added shadow

## Screenshots

<div>
<img src="https://user-images.githubusercontent.com/44158512/94298129-7b116380-ff5d-11ea-96d6-dbec7c4a2d38.png" width=300 />
</div>